### PR TITLE
fix error if I don't add "_gr" in the query

### DIFF
--- a/src/kind.js
+++ b/src/kind.js
@@ -150,7 +150,8 @@ exports.create = function createKind(name, definition, options) {
     thisSchema.virtual('owner').set(function (v) {
         this._gr[0] = v; // TODO check
     }).get(function () {
-        return this._gr[0];
+        if(this._gr){return this._gr[0];}
+        else{return;}
     });
 
     thisSchema.methods.createChild = createChild;


### PR DESCRIPTION
example:
var fields = {
        _id: 1,
        name: 1
    };
var kind = "myKind";
var options = {};
var query = {};
hds.Entry.find(kind, query, fields, options, function(err,result){});
