### PR TITLE
bump mongoose

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "async": "^0.9.0",
     "debug": "^2.2.0",
     "extend": "^3.0.0",
-    "mongoose": "4.0.0-rc4",
+    "mongoose": "^4.1.12",
     "native-or-bluebird": "^1.1.2",
     "validator": "^3.27.0"
   },


### PR DESCRIPTION
for node v4 compatibility.
fix error:
Error: Cannot find module 'mongodb/node_modules/mongodb-core/node_modules/bson'
    at Function.Module._resolveFilename (module.js:337:15)
    at Function.Module._load (module.js:287:25)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at Object.<anonymous> ([...]\node_modules\hds\node_modules\mongoose\lib\drivers\node-mongodb-native\objectid.js:8:16)
    at Module._compile (module.js:435:26)
    at Object.Module._extensions..js (module.js:442:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)